### PR TITLE
query should throw an error when an SQL error is handled

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -36,7 +36,7 @@ module.exports = (app) => {
             return result.rows
         } catch(error) {
             Logger.error('Drivers - postgresql', error)
-            return error
+            throw error
         } finally {
             client.release()
         }

--- a/test/models/schemas/user.js
+++ b/test/models/schemas/user.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 module.exports = Joi.object().keys({
     firstname:      Joi.string().optional(),
     lastname:       Joi.string().optional(),
-    favorites:      Joi.any().optional(),
+    favorites:      Joi.object().optional(),
     order:          Joi.any(),
     preferences:    Joi.array()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -38,7 +38,7 @@ describe('Postgresql driver tests', async function () {
         let id
         let firstname   = 'toto',
             lastname    = 'robert',
-            favorites   = {a: [1, 34, {'a': 2}]},
+            favorites   = {a: ["a", 34, {'a': 2}]},
             preferences = [1, 2, 3],
             order       = 1
         it('should save a user', async function () {
@@ -94,7 +94,7 @@ describe('Postgresql driver tests', async function () {
 
         it('should update a user', async function () {
 
-            let firstname = 'toto2', lastname = 'robert2', favorites = [1, 2, {'a': 2}]
+            let firstname = 'toto2', lastname = 'robert2', favorites = ["aze", "qsd"]
             const User = application.models.user
 
             const UserModel = new User({id, firstname, lastname, favorites})


### PR DESCRIPTION
For retro compatibility and APIs, the API should know when an error happens